### PR TITLE
ffmpeg 7.0系でのビルド対応

### DIFF
--- a/AviSynth/video_output.cpp
+++ b/AviSynth/video_output.cpp
@@ -900,10 +900,10 @@ void avs_set_frame_properties
     }
     if (stream && (!frame_has_primaries || !frame_has_luminance))
     {
-        const AVPacketSideData* mastering_display_side_data = av_packet_side_data_get(stream->codecpar->coded_side_data, stream->codecpar->nb_coded_side_data, AV_PKT_DATA_MASTERING_DISPLAY_METADATA);
-        if (mastering_display_side_data)
+        const AVPacketSideData* packet_side_data = av_packet_side_data_get(stream->codecpar->coded_side_data, stream->codecpar->nb_coded_side_data, AV_PKT_DATA_MASTERING_DISPLAY_METADATA);
+        if (packet_side_data)
         {
-            const AVMasteringDisplayMetadata* mastering_display = (const AVMasteringDisplayMetadata*)mastering_display_side_data->data;
+            const AVMasteringDisplayMetadata* mastering_display = (const AVMasteringDisplayMetadata*)packet_side_data->data;
             if (mastering_display->has_primaries && !frame_has_primaries)
             {
                 double display_primaries_x[3], display_primaries_y[3];
@@ -937,10 +937,10 @@ void avs_set_frame_properties
     }
     if (stream && !frame_has_light_level)
     {
-        const AVPacketSideData* side_data = av_packet_side_data_get(stream->codecpar->coded_side_data, stream->codecpar->nb_coded_side_data, AV_PKT_DATA_CONTENT_LIGHT_LEVEL);
-        if (content_light_side_data)
+        const AVPacketSideData* packet_side_data = av_packet_side_data_get(stream->codecpar->coded_side_data, stream->codecpar->nb_coded_side_data, AV_PKT_DATA_CONTENT_LIGHT_LEVEL);
+        if (packet_side_data)
         {
-            const AVContentLightMetadata* content_light = (const AVContentLightMetadata*)content_light_side_data->data;
+            const AVContentLightMetadata* content_light = (const AVContentLightMetadata*)packet_side_data->data;
             if (content_light->MaxCLL || content_light->MaxFALL)
             {
                 env->propSetInt(props, "ContentLightLevelMax", content_light->MaxCLL, 0);

--- a/common/lwindex.c
+++ b/common/lwindex.c
@@ -2085,7 +2085,7 @@ static int create_index
     }
     lwhp->format_name  = (char *)format_ctx->iformat->name;
     lwhp->format_flags = format_ctx->iformat->flags;
-    lwhp->raw_demuxer  = !!format_ctx->iformat->raw_codec_id;
+    lwhp->raw_demuxer  = format_ctx->iformat->long_name && !strncmp( format_ctx->iformat->long_name, "raw", 3 );
     vdhp->format       = format_ctx;
     adhp->format       = format_ctx;
     adhp->dv_in_avi    = !strcmp( lwhp->format_name, "avi" ) ? -1 : 0;


### PR DESCRIPTION
ffmpeg 7.0系でビルドできるようにしたく、下記2点を実施したものになります。

ffmpeg 7.0ベースでビルドした時、AVInputFormat::raw_codec_idが存在せず、コンパイルエラーとなる問題が解消できます。

- AVInputFormat::raw_codec_idが廃止されたことへの対応
  - もともとraw形式を読み込んでいるかの判定に使用されていた
  - raw系demuxerは"raw～"と名前がついているので、それを検出するよう変更

- AVStream::nb_side_dataが非推奨となったことへの対応
  - av_packet_side_data_getを使用するように変更